### PR TITLE
4.2 Fixed display flickering

### DIFF
--- a/include/tasks/core0/RemoteTask.h
+++ b/include/tasks/core0/RemoteTask.h
@@ -53,7 +53,8 @@ public:
 
     remote.charging = battery->isCharging;
     remote.percent = battery->chargePercent;
-    remote.volts = battery->getVolts();
+    // round to one decimal place
+    remote.volts = floorf(battery->getVolts() * 10) / 10;
 
     remoteBatteryQueue->send(&remote);
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ monitor_speed = 115200
 ; test_filter = test_smoother
 
 build_flags =
-  -D VERSION=4.1
+  -D VERSION=4.2
   -D VERSION_BOARD_COMPAT=4.1
   !python ./getCurrentGitBranch.py ; GIT_BRANCH_NAME
   !python ./getCurrentGitCommitHash.py ; GIT_COMMIT_HASH


### PR DESCRIPTION
Fixed display flickering by only checking remote battery every 5 seconds, and also rounding the remote battery volts to 1DP in the remote task.